### PR TITLE
Fix/#26: DB 조회 시 활성 상태만 포함

### DIFF
--- a/src/main/java/app/allstackproject/privideo/dto/organization/CreateOrgRequest.java
+++ b/src/main/java/app/allstackproject/privideo/dto/organization/CreateOrgRequest.java
@@ -23,4 +23,7 @@ public class CreateOrgRequest {
 
     @NotNull
     private String desc;
+
+    @NotNull
+    private String nickname;
 }

--- a/src/main/java/app/allstackproject/privideo/entity/BaseEntity.java
+++ b/src/main/java/app/allstackproject/privideo/entity/BaseEntity.java
@@ -1,5 +1,7 @@
 package app.allstackproject.privideo.entity;
 
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
+
 import app.allstackproject.privideo.common.enumStatus.BaseStatusType;
 import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;
@@ -31,7 +33,7 @@ public abstract class BaseEntity {
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         lastModifiedAt = LocalDateTime.now();
-        status = BaseStatusType.ACTIVE;
+        status = ACTIVE;
     }
 
     @PreUpdate
@@ -40,7 +42,7 @@ public abstract class BaseEntity {
     }
 
     public void updateToActive() {
-        this.status = BaseStatusType.ACTIVE;
+        this.status = ACTIVE;
     }
 
     public void updateToInactive() {
@@ -48,6 +50,6 @@ public abstract class BaseEntity {
     }
 
     public boolean isActive() {
-        return this.status == BaseStatusType.ACTIVE;
+        return this.status == ACTIVE;
     }
 }

--- a/src/main/java/app/allstackproject/privideo/entity/Category.java
+++ b/src/main/java/app/allstackproject/privideo/entity/Category.java
@@ -24,14 +24,18 @@ public class Category extends BaseEntity {
     @Column(unique = true)
     private String title;
 
+    private Long memberGroupId;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private Category(String title) {
+    private Category(String title, Long memberGroupId) {
         this.title = title;
+        this.memberGroupId = memberGroupId;
     }
 
-    public static Category create(String title) {
+    public static Category create(String title, Long memberGroupId) {
         return Category.builder()
                 .title(title)
+                .memberGroupId(memberGroupId)
                 .build();
     }
 }

--- a/src/main/java/app/allstackproject/privideo/repository/comment/CommentRepository.java
+++ b/src/main/java/app/allstackproject/privideo/repository/comment/CommentRepository.java
@@ -1,6 +1,5 @@
 package app.allstackproject.privideo.repository.comment;
 
-import app.allstackproject.privideo.common.enumStatus.BaseStatusType;
 import app.allstackproject.privideo.entity.Comment;
 import app.allstackproject.privideo.repository.comment.custom.CommentRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +10,4 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
     List<Comment> findByMemberIdAndVideoOrganizationId(Long memberId, Long orgId);
-
-    List<Comment> findByVideoIdAndStatus(Long videoId, BaseStatusType status);
 }

--- a/src/main/java/app/allstackproject/privideo/repository/comment/custom/CommentRepositoryImpl.java
+++ b/src/main/java/app/allstackproject/privideo/repository/comment/custom/CommentRepositoryImpl.java
@@ -1,12 +1,13 @@
 package app.allstackproject.privideo.repository.comment.custom;
 
 import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
+import static app.allstackproject.privideo.common.enumStatus.JoinStatusType.APPROVED;
+import static app.allstackproject.privideo.entity.QComment.comment;
 import static app.allstackproject.privideo.entity.QMember.member;
 import static app.allstackproject.privideo.entity.QUser.user;
 import static app.allstackproject.privideo.entity.QVideo.video;
 
 import app.allstackproject.privideo.dto.video.CommentInfo;
-import app.allstackproject.privideo.entity.QComment;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -19,18 +20,23 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
 
     @Override
     public List<CommentInfo> findAllByVideoId(Long videoId) {
-        QComment c = new QComment("c");
-
         return jpaQueryFactory
-                .select(Projections.constructor(CommentInfo.class, c.id, c.text, user.name, c.createdAt,
-                        c.parentCommentId.isNotNull(), c.parentCommentId))
-                .from(c)
-                .join(c.video, video)
-                .join(c.member, member)
+                .select(Projections.constructor(CommentInfo.class,
+                        comment.id,
+                        comment.text,
+                        user.name,
+                        comment.createdAt,
+                        comment.parentCommentId.isNotNull(),
+                        comment.parentCommentId))
+                .from(comment)
+                .join(comment.video, video)
+                .join(comment.member, member)
                 .join(member.user, user)
-                .where(video.id.eq(videoId)
-                        .and(c.status.eq(ACTIVE)))
-                .orderBy(c.createdAt.desc())
+                .where(video.id.eq(videoId),
+                        comment.member.status.eq(ACTIVE),
+                        comment.member.joinStatus.eq(APPROVED),
+                        comment.member.user.status.eq(ACTIVE))
+                .orderBy(comment.createdAt.desc())
                 .fetch();
     }
 }

--- a/src/main/java/app/allstackproject/privideo/repository/history/HistoryRepository.java
+++ b/src/main/java/app/allstackproject/privideo/repository/history/HistoryRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HistoryRepository extends JpaRepository<History, Long>, HistoryRepositoryCustom {
-    Optional<History> findByMemberIdAndVideoIdAndStatus(Long memberId, Long videoId, BaseStatusType status);
+    Optional<History> findByMemberIdAndVideoId(Long memberId, Long videoId);
 }

--- a/src/main/java/app/allstackproject/privideo/repository/history/custom/HistoryRepositoryImpl.java
+++ b/src/main/java/app/allstackproject/privideo/repository/history/custom/HistoryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package app.allstackproject.privideo.repository.history.custom;
 
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
 import static app.allstackproject.privideo.entity.QHistory.history;
 import static app.allstackproject.privideo.entity.QScrap.scrap;
 import static app.allstackproject.privideo.entity.QVideo.video;
@@ -26,7 +27,7 @@ public class HistoryRepositoryImpl implements HistoryRepositoryCustom {
                 .where(
                         scrap.member.id.eq(memberId),
                         scrap.video.id.eq(history.video.id),
-                        scrap.status.eq(BaseStatusType.ACTIVE)
+                        scrap.video.status.eq(ACTIVE)
                 )
                 .exists();
 
@@ -45,7 +46,6 @@ public class HistoryRepositoryImpl implements HistoryRepositoryCustom {
                 .join(history.video, video)
                 .where(
                         history.member.id.eq(memberId),
-                        history.status.eq(BaseStatusType.ACTIVE),
                         video.organization.id.eq(orgId)
                 )
                 .orderBy(history.lastModifiedAt.desc())

--- a/src/main/java/app/allstackproject/privideo/repository/member/MemberRepository.java
+++ b/src/main/java/app/allstackproject/privideo/repository/member/MemberRepository.java
@@ -11,13 +11,13 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
-    List<Member> findByUserId(Long userId);
+    List<Member> findByUserIdAndStatus(Long userId, BaseStatusType status);
 
     Optional<Member> findByIdAndStatus(Long id, BaseStatusType status);
 
-    Optional<Member> findByIdAndOrganizationId(Long id, Long orgId);
+    Optional<Member> findByIdAndOrganizationIdAndStatus(Long id, Long orgId, BaseStatusType status);
 
-    Optional<Member> findByUserIdAndOrganizationId(Long userId, Long orgId);
+    Optional<Member> findByUserIdAndOrganizationIdAndStatus(Long userId, Long orgId, BaseStatusType status);
 
     Optional<Member> findByOrganizationIdAndNicknameAndStatus(Long orgId, String nickname,
                                                               BaseStatusType baseStatusType);

--- a/src/main/java/app/allstackproject/privideo/repository/member/custom/MemberGroupRepositoryImpl.java
+++ b/src/main/java/app/allstackproject/privideo/repository/member/custom/MemberGroupRepositoryImpl.java
@@ -1,5 +1,6 @@
 package app.allstackproject.privideo.repository.member.custom;
 
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
 import static app.allstackproject.privideo.entity.QMemberGroupMapping.memberGroupMapping;
 import static app.allstackproject.privideo.entity.QVideoMemberGroupMapping.videoMemberGroupMapping;
 
@@ -16,7 +17,9 @@ public class MemberGroupRepositoryImpl implements MemberGroupRepositoryCustom {
         Long authorityCount = jpaQueryFactory
                 .select(videoMemberGroupMapping.count())
                 .from(videoMemberGroupMapping)
-                .where(videoMemberGroupMapping.video.id.eq(videoId))
+                .where(videoMemberGroupMapping.video.id.eq(videoId)
+                        .and(videoMemberGroupMapping.memberGroup.status.eq(ACTIVE))
+                        .and(videoMemberGroupMapping.video.status.eq(ACTIVE)))
                 .fetchOne();
 
         if (authorityCount == null || authorityCount == 0) {
@@ -28,10 +31,9 @@ public class MemberGroupRepositoryImpl implements MemberGroupRepositoryCustom {
                 .from(videoMemberGroupMapping)
                 .join(memberGroupMapping)
                 .on(videoMemberGroupMapping.memberGroup.id.eq(memberGroupMapping.memberGroup.id))
-                .where(
-                        videoMemberGroupMapping.video.id.eq(videoId),
-                        memberGroupMapping.member.id.eq(memberId)
-                )
+                .where(videoMemberGroupMapping.video.id.eq(videoId)
+                        .and(videoMemberGroupMapping.memberGroup.status.eq(ACTIVE))
+                        .and(videoMemberGroupMapping.video.status.eq(ACTIVE)))
                 .fetchOne();
 
         return accessibleCount != null && accessibleCount > 0;

--- a/src/main/java/app/allstackproject/privideo/repository/member/custom/MemberRepositoryImpl.java
+++ b/src/main/java/app/allstackproject/privideo/repository/member/custom/MemberRepositoryImpl.java
@@ -2,6 +2,7 @@ package app.allstackproject.privideo.repository.member.custom;
 
 import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
 import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.INACTIVE;
+import static app.allstackproject.privideo.common.enumStatus.JoinStatusType.APPROVED;
 import static app.allstackproject.privideo.entity.QMember.member;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -19,7 +20,8 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .update(member)
                 .set(member.status, INACTIVE)
                 .where(member.user.id.eq(userId)
-                        .and(member.status.eq(ACTIVE)))
+                        .and(member.status.eq(ACTIVE))
+                        .and(member.joinStatus.eq(APPROVED)))
                 .execute();
     }
 }

--- a/src/main/java/app/allstackproject/privideo/repository/organization/OrganizationRepository.java
+++ b/src/main/java/app/allstackproject/privideo/repository/organization/OrganizationRepository.java
@@ -1,5 +1,6 @@
 package app.allstackproject.privideo.repository.organization;
 
+import app.allstackproject.privideo.common.enumStatus.BaseStatusType;
 import app.allstackproject.privideo.entity.Organization;
 import app.allstackproject.privideo.repository.organization.custom.OrganizationRepositoryCustom;
 import java.util.Optional;
@@ -8,5 +9,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrganizationRepository extends JpaRepository<Organization, Long>, OrganizationRepositoryCustom {
-    Optional<Organization> findByName(String name);
+    Optional<Organization> findByNameAndStatus(String name, BaseStatusType status);
 }

--- a/src/main/java/app/allstackproject/privideo/repository/organization/custom/OrganizationRepositoryImpl.java
+++ b/src/main/java/app/allstackproject/privideo/repository/organization/custom/OrganizationRepositoryImpl.java
@@ -4,7 +4,6 @@ import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTI
 import static app.allstackproject.privideo.entity.QMember.member;
 import static app.allstackproject.privideo.entity.QOrganization.organization;
 
-import app.allstackproject.privideo.dto.organization.ReadOrgDto;
 import app.allstackproject.privideo.dto.organization.ReadOrgResult;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -31,7 +30,8 @@ public class OrganizationRepositoryImpl implements OrganizationRepositoryCustom 
                 .from(member)
                 .join(member.organization, organization)
                 .where(member.user.id.eq(userId)
-                        .and(member.status.eq(ACTIVE)))
+                        .and(member.status.eq(ACTIVE))
+                        .and(organization.status.eq(ACTIVE)))
                 .fetch();
     }
 }

--- a/src/main/java/app/allstackproject/privideo/repository/quiz/MemberQuizResultRepository.java
+++ b/src/main/java/app/allstackproject/privideo/repository/quiz/MemberQuizResultRepository.java
@@ -1,10 +1,11 @@
 package app.allstackproject.privideo.repository.quiz;
 
+import app.allstackproject.privideo.common.enumStatus.BaseStatusType;
 import app.allstackproject.privideo.entity.MemberQuizResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberQuizResultRepository extends JpaRepository<MemberQuizResult, Long> {
-    boolean existsByQuizId(Long quizId);
+    boolean existsByQuizIdAndStatus(Long quizId, BaseStatusType status);
 }

--- a/src/main/java/app/allstackproject/privideo/repository/quiz/custom/QuizRepositoryImpl.java
+++ b/src/main/java/app/allstackproject/privideo/repository/quiz/custom/QuizRepositoryImpl.java
@@ -1,6 +1,7 @@
 package app.allstackproject.privideo.repository.quiz.custom;
 
 import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
+import static app.allstackproject.privideo.common.enumStatus.JoinStatusType.APPROVED;
 import static app.allstackproject.privideo.entity.QMemberQuizResult.memberQuizResult;
 import static app.allstackproject.privideo.entity.QQuiz.quiz;
 import static app.allstackproject.privideo.entity.QVideo.video;
@@ -35,7 +36,9 @@ public class QuizRepositoryImpl implements QuizRepositoryCustom {
                 .join(quiz.video, video)
                 .where(
                         memberQuizResult.member.id.eq(memberId),
-                        video.organization.id.eq(orgId)
+                        video.organization.id.eq(orgId),
+                        memberQuizResult.member.status.eq(ACTIVE),
+                        memberQuizResult.member.joinStatus.eq(APPROVED)
                 )
                 .orderBy(memberQuizResult.submittedAt.desc())
                 .fetch();
@@ -56,8 +59,10 @@ public class QuizRepositoryImpl implements QuizRepositoryCustom {
                 .join(memberQuizResult.quiz, quiz)
                 .join(quiz.video, video)
                 .where(
-                        video.id.eq(videoId)
-                                .and(video.status.eq(ACTIVE)))
+                        video.id.eq(videoId),
+                        video.status.eq(ACTIVE),
+                        memberQuizResult.member.status.eq(ACTIVE),
+                        memberQuizResult.member.joinStatus.eq(APPROVED))
                 .fetch();
     }
 

--- a/src/main/java/app/allstackproject/privideo/repository/scrap/ScrapRepository.java
+++ b/src/main/java/app/allstackproject/privideo/repository/scrap/ScrapRepository.java
@@ -1,15 +1,12 @@
 package app.allstackproject.privideo.repository.scrap;
 
+import app.allstackproject.privideo.common.enumStatus.BaseStatusType;
 import app.allstackproject.privideo.entity.Scrap;
 import app.allstackproject.privideo.repository.scrap.custom.ScrapRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapRepositoryCustom {
-    List<Scrap> findByMemberIdAndVideoOrganizationId(Long memberId, Long orgId);
-
-    boolean existsByMemberIdAndVideoId(Long memberId, Long videoId);
+    boolean existsByMemberIdAndVideoIdAndStatus(Long memberId, Long videoId, BaseStatusType status);
 }

--- a/src/main/java/app/allstackproject/privideo/repository/scrap/custom/ScrapRepositoryImpl.java
+++ b/src/main/java/app/allstackproject/privideo/repository/scrap/custom/ScrapRepositoryImpl.java
@@ -9,7 +9,6 @@ import static app.allstackproject.privideo.entity.QScrap.scrap;
 import static app.allstackproject.privideo.entity.QVideo.video;
 import static app.allstackproject.privideo.entity.QVideoMemberGroupMapping.videoMemberGroupMapping;
 
-import app.allstackproject.privideo.common.enumStatus.BaseStatusType;
 import app.allstackproject.privideo.dto.history.HistoryItem;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -28,6 +27,7 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
         BooleanExpression openToAll = JPAExpressions.selectOne()
                 .from(videoMemberGroupMapping)
                 .where(videoMemberGroupMapping.video.id.eq(videoId),
+                        videoMemberGroupMapping.memberGroup.status.eq(ACTIVE),
                         videoMemberGroupMapping.status.eq(ACTIVE))
                 .notExists();
 
@@ -38,6 +38,7 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
                         .and(memberGroupMapping.member.id.eq(memberId))
                         .and(memberGroupMapping.status.eq(ACTIVE)))
                 .where(videoMemberGroupMapping.video.id.eq(videoId),
+                        videoMemberGroupMapping.memberGroup.status.eq(ACTIVE),
                         videoMemberGroupMapping.status.eq(ACTIVE))
                 .exists();
 
@@ -78,9 +79,7 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
                 .from(scrap)
                 .where(
                         scrap.member.id.eq(memberId),
-                        scrap.video.id.eq(history.video.id),
-                        scrap.status.eq(BaseStatusType.ACTIVE)
-                )
+                        scrap.video.id.eq(history.video.id))
                 .exists();
 
         return jpaQueryFactory
@@ -97,7 +96,8 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
                 .join(history.video, video)
                 .where(
                         history.member.id.eq(memberId),
-                        history.status.eq(BaseStatusType.ACTIVE),
+                        history.member.status.eq(ACTIVE),
+                        history.member.joinStatus.eq(APPROVED),
                         video.organization.id.eq(orgId),
                         scrappedExists
                 )

--- a/src/main/java/app/allstackproject/privideo/repository/user/UserRepository.java
+++ b/src/main/java/app/allstackproject/privideo/repository/user/UserRepository.java
@@ -1,5 +1,6 @@
 package app.allstackproject.privideo.repository.user;
 
+import app.allstackproject.privideo.common.enumStatus.BaseStatusType;
 import app.allstackproject.privideo.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,7 +8,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    boolean existsByEmail(String email);
+    boolean existsByEmailAndStatus(String email, BaseStatusType status);
 
-    Optional<User> findByEmail(String email);
+    Optional<User> findByEmailAndStatus(String email, BaseStatusType status);
 }

--- a/src/main/java/app/allstackproject/privideo/repository/video/custom/CategoryRepositoryImpl.java
+++ b/src/main/java/app/allstackproject/privideo/repository/video/custom/CategoryRepositoryImpl.java
@@ -1,9 +1,9 @@
 package app.allstackproject.privideo.repository.video.custom;
 
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
 import static app.allstackproject.privideo.entity.QCategory.category;
 import static app.allstackproject.privideo.entity.QVideoCategoryMapping.videoCategoryMapping;
 
-import app.allstackproject.privideo.common.enumStatus.BaseStatusType;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +20,8 @@ public class CategoryRepositoryImpl implements CategoryRepositoryCustom {
                 .from(videoCategoryMapping)
                 .join(videoCategoryMapping.category, category)
                 .where(videoCategoryMapping.video.id.eq(videoId)
-                        .and(videoCategoryMapping.status.eq(BaseStatusType.ACTIVE))
-                        .and(category.status.eq(BaseStatusType.ACTIVE)))
+                        .and(videoCategoryMapping.status.eq(ACTIVE))
+                        .and(category.status.eq(ACTIVE)))
                 .orderBy(category.title.asc())
                 .fetch();
     }

--- a/src/main/java/app/allstackproject/privideo/repository/video/custom/VideoRepositoryImpl.java
+++ b/src/main/java/app/allstackproject/privideo/repository/video/custom/VideoRepositoryImpl.java
@@ -19,38 +19,60 @@ public class VideoRepositoryImpl implements VideoRepositoryCustom {
 
     @Override
     public boolean isValidMemberAndOrgAndVideo(Long memberId, Long orgId, Long videoId) {
-        BooleanExpression openToAll = JPAExpressions.selectOne()
-                .from(videoMemberGroupMapping)
-                .where(videoMemberGroupMapping.video.id.eq(videoId),
-                        videoMemberGroupMapping.status.eq(ACTIVE))
-                .notExists();
-
-        BooleanExpression memberGroupMatch = JPAExpressions.selectOne()
-                .from(videoMemberGroupMapping)
-                .join(memberGroupMapping)
-                .on(memberGroupMapping.memberGroup.id.eq(videoMemberGroupMapping.memberGroup.id)
-                        .and(memberGroupMapping.member.id.eq(memberId))
-                        .and(memberGroupMapping.status.eq(ACTIVE)))
-                .where(videoMemberGroupMapping.video.id.eq(videoId),
-                        videoMemberGroupMapping.status.eq(ACTIVE))
-                .exists();
-
-        Integer ok = jpaQueryFactory
+        Integer result = jpaQueryFactory
                 .selectOne()
                 .from(video)
-                .join(member).on(
-                        member.id.eq(memberId),
-                        member.organization.id.eq(orgId),
-                        member.status.eq(ACTIVE),
-                        member.joinStatus.eq(APPROVED))
+                .join(member).on(member.id.eq(memberId))
                 .where(
                         video.id.eq(videoId),
                         video.organization.id.eq(orgId),
                         video.status.eq(ACTIVE),
-                        openToAll.or(memberGroupMatch)
+
+                        member.organization.id.eq(orgId),
+                        member.status.eq(ACTIVE),
+                        member.joinStatus.eq(APPROVED),
+
+                        isVideoAccessibleByMember(videoId, memberId)
                 )
                 .fetchFirst();
 
-        return ok != null;
+        return result != null;
+    }
+
+    /**
+     * 비디오에 대한 멤버의 접근 권한 확인
+     * - VideoMemberGroupMapping이 없으면 전체 공개 (OK)
+     * - VideoMemberGroupMapping이 있으면 멤버가 해당 그룹에 속해야 함
+     */
+    private BooleanExpression isVideoAccessibleByMember(Long videoId, Long memberId) {
+        BooleanExpression noGroupRestriction = JPAExpressions
+                .selectOne()
+                .from(videoMemberGroupMapping)
+                .where(
+                        videoMemberGroupMapping.video.id.eq(videoId),
+                        videoMemberGroupMapping.status.eq(ACTIVE)
+                )
+                .notExists();
+
+        BooleanExpression memberInAllowedGroup = JPAExpressions
+                .select(memberGroupMapping.memberGroup.id)
+                .from(memberGroupMapping)
+                .where(
+                        memberGroupMapping.member.id.eq(memberId),
+                        memberGroupMapping.status.eq(ACTIVE),
+                        memberGroupMapping.member.joinStatus.eq(APPROVED),
+                        memberGroupMapping.memberGroup.id.in(
+                                JPAExpressions
+                                        .select(videoMemberGroupMapping.memberGroup.id)
+                                        .from(videoMemberGroupMapping)
+                                        .where(
+                                                videoMemberGroupMapping.video.id.eq(videoId),
+                                                videoMemberGroupMapping.status.eq(ACTIVE)
+                                        )
+                        )
+                )
+                .exists();
+
+        return noGroupRestriction.or(memberInAllowedGroup);
     }
 }

--- a/src/main/java/app/allstackproject/privideo/service/CommentService.java
+++ b/src/main/java/app/allstackproject/privideo/service/CommentService.java
@@ -39,7 +39,6 @@ public class CommentService {
     }
 
     public boolean deleteComment(Long memberId, Long orgId, Long commentId) {
-
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new ApiException(COMMENT_NOT_FOUND));
 

--- a/src/main/java/app/allstackproject/privideo/service/QuizService.java
+++ b/src/main/java/app/allstackproject/privideo/service/QuizService.java
@@ -1,5 +1,6 @@
 package app.allstackproject.privideo.service;
 
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.ALREADY_SOLVED_QUIZ;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.INVALID_QUIZ_REQUEST;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.QUIZ_NOT_FOUND;
@@ -50,7 +51,7 @@ public class QuizService {
                 throw new ApiException(QUIZ_NOT_FOUND);
             }
 
-            if (memberQuizResultRepository.existsByQuizId(quizId)) {
+            if (memberQuizResultRepository.existsByQuizIdAndStatus(quizId, ACTIVE)) {
                 throw new ApiException(ALREADY_SOLVED_QUIZ);
             }
 

--- a/src/main/java/app/allstackproject/privideo/service/admin/AdminService.java
+++ b/src/main/java/app/allstackproject/privideo/service/admin/AdminService.java
@@ -1,5 +1,6 @@
 package app.allstackproject.privideo.service.admin;
 
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
 import static app.allstackproject.privideo.common.enumStatus.JoinStatusType.APPROVED;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.CREATOR_CANNOT_CHANGE;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.FORBIDDEN_NO_PERMISSION;
@@ -46,7 +47,7 @@ public class AdminService {
         if (!organizationRepository.existsById(orgId)) {
             throw new ApiException(ORGANIZATION_NOT_FOUND);
         }
-        Member admin = memberRepository.findByUserIdAndOrganizationId(adminUserId, orgId)
+        Member admin = memberRepository.findByUserIdAndOrganizationIdAndStatus(adminUserId, orgId, ACTIVE)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
         if (!admin.isAdmin()) {
             throw new ApiException(FORBIDDEN_NO_PERMISSION);
@@ -55,7 +56,7 @@ public class AdminService {
         Long targetMemberId = changeJoinStateRequest.getMemberId();
         JoinStatusType targetStatus = JoinStatusType.valueOf(changeJoinStateRequest.getStatus());
 
-        Member targetMember = memberRepository.findByIdAndOrganizationId(targetMemberId, orgId)
+        Member targetMember = memberRepository.findByIdAndOrganizationIdAndStatus(targetMemberId, orgId, ACTIVE)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
 
         targetMember.changeJoinStatus(targetStatus);
@@ -95,14 +96,14 @@ public class AdminService {
         }
 
         // TODO: 여기서 MEMBER_NOT_FOUND : /admin/orgs/perm
-        Member admin = memberRepository.findByIdAndOrganizationId(adminUserId, orgId)
+        Member admin = memberRepository.findByIdAndOrganizationIdAndStatus(adminUserId, orgId, ACTIVE)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
 
         if (!admin.isAdmin()) {
             throw new ApiException(FORBIDDEN_NO_PERMISSION);
         }
 
-        Member targetMember = memberRepository.findByUserIdAndOrganizationId(targetMemberId, orgId)
+        Member targetMember = memberRepository.findByUserIdAndOrganizationIdAndStatus(targetMemberId, orgId, ACTIVE)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
 
         if (targetMember.isAdmin() && targetMember.getOrganization().getCreator().getId()
@@ -155,7 +156,7 @@ public class AdminService {
         organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ApiException(ORGANIZATION_NOT_FOUND));
 
-        Member member = memberRepository.findByUserIdAndOrganizationId(userId, orgId)
+        Member member = memberRepository.findByUserIdAndOrganizationIdAndStatus(userId, orgId, ACTIVE)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
 
         if (member.getJoinStatus() != APPROVED) {

--- a/src/main/java/app/allstackproject/privideo/service/organization/OrganizationService.java
+++ b/src/main/java/app/allstackproject/privideo/service/organization/OrganizationService.java
@@ -55,7 +55,7 @@ public class OrganizationService {
         Organization organization = Organization.create(user, createOrgRequest.getName(), imgUrl,
                 createOrgRequest.getDesc());
 
-        Member member = Member.create(user, organization, user.getName(), true, APPROVED);
+        Member member = Member.create(user, organization, createOrgRequest.getNickname(), true, APPROVED);
         member.adminPermissionSet();
 
         organizationRepository.save(organization);

--- a/src/main/java/app/allstackproject/privideo/service/organization/OrganizationService.java
+++ b/src/main/java/app/allstackproject/privideo/service/organization/OrganizationService.java
@@ -92,7 +92,7 @@ public class OrganizationService {
             throw new ApiException(USER_NOT_FOUND);
         }
 
-        if (organizationRepository.findByName(orgName).isPresent()) {
+        if (organizationRepository.findByNameAndStatus(orgName, ACTIVE).isPresent()) {
             return false;
         }
 
@@ -144,7 +144,7 @@ public class OrganizationService {
             throw new ApiException(ORG_CODE_NOT_AVAILABLE);
         }
 
-        Optional<Member> existMember = memberRepository.findByUserIdAndOrganizationId(userId, orgId);
+        Optional<Member> existMember = memberRepository.findByUserIdAndOrganizationIdAndStatus(userId, orgId, ACTIVE);
 
         if (existMember.isPresent()) {
             Member member = existMember.get();
@@ -190,7 +190,7 @@ public class OrganizationService {
         userRepository.findById(userId).orElseThrow(() -> new ApiException(USER_NOT_FOUND));
         organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ApiException(ORGANIZATION_NOT_FOUND));
-        Member member = memberRepository.findByUserIdAndOrganizationId(userId, orgId)
+        Member member = memberRepository.findByUserIdAndOrganizationIdAndStatus(userId, orgId, ACTIVE)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
 
         if (member.getJoinStatus() != APPROVED) {
@@ -213,7 +213,7 @@ public class OrganizationService {
         userRepository.findById(userId).orElseThrow(() -> new ApiException(USER_NOT_FOUND));
         organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ApiException(ORGANIZATION_NOT_FOUND));
-        Member member = memberRepository.findByUserIdAndOrganizationId(userId, orgId)
+        Member member = memberRepository.findByUserIdAndOrganizationIdAndStatus(userId, orgId, ACTIVE)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
 
         try {

--- a/src/main/java/app/allstackproject/privideo/service/permission/PermissionService.java
+++ b/src/main/java/app/allstackproject/privideo/service/permission/PermissionService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.MEMBER_NOT_FOUND;
 
 @Slf4j
@@ -32,7 +33,7 @@ public class PermissionService {
 
         log.info("Redis fallback, DB 조회");
 
-        Member member = memberRepository.findByIdAndOrganizationId(orgId, memberId)
+        Member member = memberRepository.findByIdAndOrganizationIdAndStatus(memberId, orgId, ACTIVE)
                 .orElseThrow(() -> {
                     return new ApiException(MEMBER_NOT_FOUND);
                 });

--- a/src/main/java/app/allstackproject/privideo/service/user/UserService.java
+++ b/src/main/java/app/allstackproject/privideo/service/user/UserService.java
@@ -1,5 +1,6 @@
 package app.allstackproject.privideo.service.user;
 
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
 import static app.allstackproject.privideo.common.enumStatus.JoinStatusType.PENDING;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.DB_CONSTRAINT_VIOLATE;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.DUPLICATE_EMAIL;
@@ -45,7 +46,7 @@ public class UserService {
     private final OrgRedisRepository orgRedisRepository;
 
     public boolean signup(@Valid PostSignupRequest postSignupRequest) {
-        if (userRepository.existsByEmail(postSignupRequest.getEmail())) {
+        if (userRepository.existsByEmailAndStatus(postSignupRequest.getEmail(), ACTIVE)) {
             throw new ApiException(DUPLICATE_EMAIL);
         }
 
@@ -83,7 +84,7 @@ public class UserService {
     public String login(@Valid PostLoginRequest postLoginRequest) {
         String email = postLoginRequest.getEmail();
 
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findByEmailAndStatus(email, ACTIVE)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
 
         if (!user.matchPassword(postLoginRequest.getPassword(), passwordEncoder)) {
@@ -97,7 +98,7 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
 
-        List<Member> members = memberRepository.findByUserId(userId);
+        List<Member> members = memberRepository.findByUserIdAndStatus(userId, ACTIVE);
         return UserInfoResponse.of(user, members);
     }
 

--- a/src/main/java/app/allstackproject/privideo/service/video/ScrapService.java
+++ b/src/main/java/app/allstackproject/privideo/service/video/ScrapService.java
@@ -1,5 +1,6 @@
 package app.allstackproject.privideo.service.video;
 
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.INVALID_SCRAP_REQUEST;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.VIDEO_ALREADY_SCRAPPED;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.VIDEO_NOT_SCRAPPED;
@@ -38,7 +39,7 @@ public class ScrapService {
         }
 
         try {
-            if (scrapRepository.existsByMemberIdAndVideoId(memberId, videoId)) {
+            if (scrapRepository.existsByMemberIdAndVideoIdAndStatus(memberId, videoId, ACTIVE)) {
                 throw new ApiException(VIDEO_ALREADY_SCRAPPED);
             }
             scrapRepository.save(Scrap.create(memberRepository.getReferenceById(memberId),

--- a/src/main/java/app/allstackproject/privideo/service/video/VideoService.java
+++ b/src/main/java/app/allstackproject/privideo/service/video/VideoService.java
@@ -81,7 +81,7 @@ public class VideoService {
         List<String> categories = categoryRepository.findAllByVideoId(videoId);
 
         boolean isScrapped = false;
-        if (scrapRepository.existsByMemberIdAndVideoId(memberId, videoId)) {
+        if (scrapRepository.existsByMemberIdAndVideoIdAndStatus(memberId, videoId, ACTIVE)) {
             isScrapped = true;
         }
 
@@ -89,7 +89,7 @@ public class VideoService {
                 (int) Math.ceil((double) video.getWholeTime() / SEGMENT_SECONDS));
 
         boolean isFirstWatch = true;
-        Optional<History> history = historyRepository.findByMemberIdAndVideoIdAndStatus(memberId, videoId, ACTIVE);
+        Optional<History> history = historyRepository.findByMemberIdAndVideoId(memberId, videoId);
         // 시청 기록 있는지 확인
         if (history.isPresent()) {
             if (history.get().isComplete()) {
@@ -143,7 +143,7 @@ public class VideoService {
 
         // TODO: Redis에서 세션 키 삭제
         if (isFirstWatch) {
-            History history = historyRepository.findByMemberIdAndVideoIdAndStatus(memberId, videoId, ACTIVE)
+            History history = historyRepository.findByMemberIdAndVideoId(memberId, videoId)
                     .orElseThrow(() -> new ApiException(HISTORY_NOT_FOUND));
 
             boolean watchEnd = watchedSegments.testBit(totalSegCnt - 1);


### PR DESCRIPTION
## 📝 요약

- resolved #26 

## 🔖 변경 사항
- 조직 생성 요청에 닉네임 필드 추가
- `Category` 엔티티에 `MemberGroupId` 칼럼 추가
- DB 조회 시 status `ACTIVE`인 데이터만 조회

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
