### PR TITLE
Hotfix/#66: 영상 세션 종료 시 토큰 미검증

### DIFF
--- a/src/main/java/app/allstackproject/privideo/common/config/JwtSecurityProperties.java
+++ b/src/main/java/app/allstackproject/privideo/common/config/JwtSecurityProperties.java
@@ -1,0 +1,17 @@
+package app.allstackproject.privideo.common.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "secret.jwt")
+public class JwtSecurityProperties {
+
+    private List<String> excludedPatterns = new ArrayList<>();
+}

--- a/src/main/java/app/allstackproject/privideo/common/config/SecurityConfig.java
+++ b/src/main/java/app/allstackproject/privideo/common/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import app.allstackproject.privideo.common.exception.handler.CustomAuthEntryPoin
 import app.allstackproject.privideo.common.filter.JwtAuthFilter;
 import app.allstackproject.privideo.common.jwt.JwtProvider;
 import app.allstackproject.privideo.repository.organization.OrgRedisRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +31,7 @@ public class SecurityConfig {
     private final CustomAuthEntryPoint customAuthEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final OrgRedisRepository orgRedisRepository;
+    private final JwtSecurityProperties jwtSecurityProperties;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -37,6 +40,10 @@ public class SecurityConfig {
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        System.out.println("=== SecurityFilterChain 생성 시작 ===");
+        String[] permitPatterns = buildPermitPatterns();
+        System.out.println("permitPatterns 개수: " + permitPatterns.length);
+
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .headers((headerConfig) ->
@@ -45,9 +52,7 @@ public class SecurityConfig {
                 )
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/error", "/favicon.ico",
-                                "/user/signup", "/user/login",
-                                "/h2-console/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**")
+                        .requestMatchers(permitPatterns)
                         .permitAll()
                         .anyRequest().authenticated()
                 )
@@ -62,5 +67,25 @@ public class SecurityConfig {
         ;
 
         return http.build();
+    }
+
+    private String[] buildPermitPatterns() {
+        System.out.println("=== buildPermitPatterns 호출됨 ===");
+        List<String> staticPatterns = List.of(
+                "/error", "/favicon.ico",
+                "/h2-console/**", "/v3/api-docs/**",
+                "/swagger-ui.html", "/swagger-ui/**"
+        );
+
+        List<String> combined = new ArrayList<>(staticPatterns);
+
+        List<String> excludedPatterns = jwtSecurityProperties.getExcludedPatterns();
+        System.out.println("excludedPatterns: " + excludedPatterns);
+
+        if (excludedPatterns != null && !excludedPatterns.isEmpty()) {
+            combined.addAll(excludedPatterns);
+        }
+
+        return combined.toArray(new String[0]);
     }
 }

--- a/src/main/java/app/allstackproject/privideo/common/config/SwaggerConfig.java
+++ b/src/main/java/app/allstackproject/privideo/common/config/SwaggerConfig.java
@@ -6,9 +6,7 @@ import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/app/allstackproject/privideo/controller/video/VideoController.java
+++ b/src/main/java/app/allstackproject/privideo/controller/video/VideoController.java
@@ -37,7 +37,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/{orgId}/video")
-@PreAuthorize("hasAuthority('org:granted')")
 @Tag(name = "Video", description = "영상 관련 API")
 @SecurityRequirement(name = ORG_AUTH_KEY)
 public class VideoController {
@@ -46,6 +45,7 @@ public class VideoController {
     private final CloudFrontCookieService cloudFrontCookieService;
 
     @PostMapping("")
+    @PreAuthorize("hasAuthority('org:granted')")
     @Operation(summary = "영상 업로드")
     public BaseResponse<CreateVideoResponse> createVideo(
             @AuthenticationPrincipal(expression = "memberId") Long memberId,
@@ -65,6 +65,7 @@ public class VideoController {
     }
 
     @PutMapping("/{videoId}")
+    @PreAuthorize("hasAuthority('org:granted')")
     @Operation(summary = "영상 업로드 성공 여부")
     public BaseResponse<SuccessResponse> notifyVideoEncodingResult(
             @AuthenticationPrincipal(expression = "memberId") Long memberId,
@@ -76,6 +77,7 @@ public class VideoController {
     }
 
     @PostMapping("/{videoId}/join")
+    @PreAuthorize("hasAuthority('org:granted')")
     @Operation(summary = "영상 시청 세션 시작")
     public BaseResponse<JoinVideoSessionResponse> joinVideoSession(
             @AuthenticationPrincipal(expression = "memberId") Long memberId, @PathVariable("orgId") Long orgId,
@@ -88,15 +90,15 @@ public class VideoController {
 
     @PostMapping("/{videoId}/leave")
     @Operation(summary = "영상 시청 세션 종료")
-    public BaseResponse<SuccessResponse> leaveVideoSession(
-            @AuthenticationPrincipal(expression = "memberId") Long memberId, @PathVariable("orgId") Long orgId,
-            @PathVariable("videoId") Long videoId,
-            @Valid @RequestBody LeaveVideoSessionRequest leaveVideoSessionRequest, BindingResult bindingResult) {
+    public BaseResponse<SuccessResponse> leaveVideoSession(@PathVariable("orgId") Long orgId,
+                                                           @PathVariable("videoId") Long videoId,
+                                                           @Valid @RequestBody LeaveVideoSessionRequest leaveVideoSessionRequest,
+                                                           BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new ApiException(INVALID_VIDEO_LEAVE, getErrorMessage(bindingResult));
         }
 
-        LeaveVideoSessionInfo leaveVideoSessionInfo = LeaveVideoSessionInfo.create(memberId, orgId, videoId,
+        LeaveVideoSessionInfo leaveVideoSessionInfo = LeaveVideoSessionInfo.create(orgId, videoId,
                 leaveVideoSessionRequest);
         boolean result = videoService.leaveVideoSession(leaveVideoSessionInfo);
         return new BaseResponse<>(SuccessResponse.of(result));

--- a/src/main/java/app/allstackproject/privideo/controller/video/VideoController.java
+++ b/src/main/java/app/allstackproject/privideo/controller/video/VideoController.java
@@ -98,7 +98,8 @@ public class VideoController {
             throw new ApiException(INVALID_VIDEO_LEAVE, getErrorMessage(bindingResult));
         }
 
-        LeaveVideoSessionInfo leaveVideoSessionInfo = LeaveVideoSessionInfo.create(orgId, videoId,
+        LeaveVideoSessionInfo leaveVideoSessionInfo = LeaveVideoSessionInfo.create(
+                leaveVideoSessionRequest.getMemberId(), orgId, videoId,
                 leaveVideoSessionRequest);
         boolean result = videoService.leaveVideoSession(leaveVideoSessionInfo);
         return new BaseResponse<>(SuccessResponse.of(result));

--- a/src/main/java/app/allstackproject/privideo/dto/video/LeaveVideoSessionInfo.java
+++ b/src/main/java/app/allstackproject/privideo/dto/video/LeaveVideoSessionInfo.java
@@ -35,10 +35,8 @@ public class LeaveVideoSessionInfo {
         this.isQuit = isQuit;
     }
 
-    public static LeaveVideoSessionInfo create(Long orgId, Long videoId,
+    public static LeaveVideoSessionInfo create(Long memberId, Long orgId, Long videoId,
                                                LeaveVideoSessionRequest leaveVideoSessionRequest) {
-        // TODO: session_id로부터 member_id 가져오기
-        Long memberId = 0L;
         return LeaveVideoSessionInfo.builder()
                 .memberId(memberId)
                 .orgId(orgId)

--- a/src/main/java/app/allstackproject/privideo/dto/video/LeaveVideoSessionInfo.java
+++ b/src/main/java/app/allstackproject/privideo/dto/video/LeaveVideoSessionInfo.java
@@ -35,8 +35,10 @@ public class LeaveVideoSessionInfo {
         this.isQuit = isQuit;
     }
 
-    public static LeaveVideoSessionInfo create(Long memberId, Long orgId, Long videoId,
+    public static LeaveVideoSessionInfo create(Long orgId, Long videoId,
                                                LeaveVideoSessionRequest leaveVideoSessionRequest) {
+        // TODO: session_id로부터 member_id 가져오기
+        Long memberId = 0L;
         return LeaveVideoSessionInfo.builder()
                 .memberId(memberId)
                 .orgId(orgId)

--- a/src/main/java/app/allstackproject/privideo/dto/video/LeaveVideoSessionRequest.java
+++ b/src/main/java/app/allstackproject/privideo/dto/video/LeaveVideoSessionRequest.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeaveVideoSessionRequest {
+    private Long memberId;
+
     @NotBlank(message = "세션키는 공백일 수 없습니다.")
     private String sessionId;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -122,6 +122,7 @@ secret:
   jwt:
     secret-key: ${TOKEN_SECRET_KEY}
     expired-in: ${TOKEN_EXPIRED_IN}
+    excluded-patterns: ${JWT_EXCLUDED_PATTERNS:}
 ---
 spring:
   config:


### PR DESCRIPTION
## 📝 요약

- resolved #66 

## 🔖 변경 사항
- 토큰 미검증 API에 대해 security filter에서 제외

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비디오 세션 관리 요청에 멤버 정보 포함 기능 추가

* **개선 사항**
  * 비디오 관련 작업에 대한 보안 권한 검증 강화
  * JWT 보안 설정에서 인증 예외 패턴을 유연하게 구성할 수 있도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->