### PR TITLE
Fix: 1차 통합 테스트 결과 발생 버그 수정

### DIFF
--- a/src/main/java/app/allstackproject/privideo/common/filter/JwtAuthFilter.java
+++ b/src/main/java/app/allstackproject/privideo/common/filter/JwtAuthFilter.java
@@ -119,12 +119,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     Long redisPermission = null;
                     try {
                         redisPermission = orgRedisRepository.getMemberPermission(orgId, memberId);
-                        if (redisPermission == null) {
-                            log.warn("Redis에 권한 없음 - 탈퇴한 멤버로 처리. memberId: {}, orgId: {}", memberId, orgId);
-                            throw new ApiException(ALREADY_LEAVED_MEMBER); // or INVALID_TOKEN으로 처리? 프론트 편한 대로
-                        }
 
-                        if (!redisPermission.equals(perm)) {
+                        if (redisPermission != null && !redisPermission.equals(perm)) {
                             log.info("권한 변경 감지 - memberId: {}, 기존: {}, 최신: {}", memberId, perm, redisPermission);
                             String newToken = jwtProvider.createOrgToken(OrgTokenDto.builder()
                                     .userId(userId)
@@ -138,6 +134,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                         }
                     } catch (Exception e) {
                         log.warn("Redis 조회 실패", e);
+                    }
+
+                    if (redisPermission == null) {
+                        log.warn("Redis에 권한 없음 - 탈퇴한 멤버로 처리. memberId: {}, orgId: {}", memberId, orgId);
+                        throw new ApiException(ALREADY_LEAVED_MEMBER);
                     }
 
                     long finalPerm = (redisPermission != null) ? redisPermission : perm;

--- a/src/main/java/app/allstackproject/privideo/common/filter/JwtAuthFilter.java
+++ b/src/main/java/app/allstackproject/privideo/common/filter/JwtAuthFilter.java
@@ -1,5 +1,6 @@
 package app.allstackproject.privideo.common.filter;
 
+import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.ALREADY_LEAVED_MEMBER;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.FORBIDDEN_ORG_MISMATCH;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.INVALID_TOKEN;
 
@@ -118,7 +119,12 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     Long redisPermission = null;
                     try {
                         redisPermission = orgRedisRepository.getMemberPermission(orgId, memberId);
-                        if (redisPermission != null && !redisPermission.equals(perm)) {
+                        if (redisPermission == null) {
+                            log.warn("Redis에 권한 없음 - 탈퇴한 멤버로 처리. memberId: {}, orgId: {}", memberId, orgId);
+                            throw new ApiException(ALREADY_LEAVED_MEMBER); // or INVALID_TOKEN으로 처리? 프론트 편한 대로
+                        }
+
+                        if (!redisPermission.equals(perm)) {
                             log.info("권한 변경 감지 - memberId: {}, 기존: {}, 최신: {}", memberId, perm, redisPermission);
                             String newToken = jwtProvider.createOrgToken(OrgTokenDto.builder()
                                     .userId(userId)

--- a/src/main/java/app/allstackproject/privideo/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/app/allstackproject/privideo/common/response/status/BaseExceptionResponseStatus.java
@@ -55,7 +55,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     DUPLICATE_NICKNAME(5014, HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     INVALID_AGE_TYPE(5015, HttpStatus.BAD_REQUEST, "나이는 10, 20, 30, 40, 50, 60 중 하나여야 합니다."),
     ALREADY_LEAVED_USER(5016, HttpStatus.BAD_REQUEST, "탈퇴 이력이 있는 회원입니다."),
-    ALREADY_LEAVED_MEMBER(5017, HttpStatus.BAD_REQUEST, "해당 조직에 대해 탈퇴 이력이 있는 멤버입니다."),
+    ALREADY_LEAVED_MEMBER(5017, HttpStatus.BAD_REQUEST, "해당 조직에 대해 탈퇴한 멤버입니다."),
 
     /**
      * 6000: Comment 오류

--- a/src/main/java/app/allstackproject/privideo/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/app/allstackproject/privideo/common/response/status/BaseExceptionResponseStatus.java
@@ -54,6 +54,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     MEMBER_NOT_IN_ORGANIZATION(5013, HttpStatus.NOT_FOUND, "해당 조직에서 찾을 수 없는 멤버입니다."),
     DUPLICATE_NICKNAME(5014, HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     INVALID_AGE_TYPE(5015, HttpStatus.BAD_REQUEST, "나이는 10, 20, 30, 40, 50, 60 중 하나여야 합니다."),
+    ALREADY_LEAVED_USER(5016, HttpStatus.BAD_REQUEST, "탈퇴 이력이 있는 회원입니다."),
 
     /**
      * 6000: Comment 오류

--- a/src/main/java/app/allstackproject/privideo/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/app/allstackproject/privideo/common/response/status/BaseExceptionResponseStatus.java
@@ -55,6 +55,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     DUPLICATE_NICKNAME(5014, HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     INVALID_AGE_TYPE(5015, HttpStatus.BAD_REQUEST, "나이는 10, 20, 30, 40, 50, 60 중 하나여야 합니다."),
     ALREADY_LEAVED_USER(5016, HttpStatus.BAD_REQUEST, "탈퇴 이력이 있는 회원입니다."),
+    ALREADY_LEAVED_MEMBER(5017, HttpStatus.BAD_REQUEST, "해당 조직에 대해 탈퇴 이력이 있는 멤버입니다."),
 
     /**
      * 6000: Comment 오류

--- a/src/main/java/app/allstackproject/privideo/dto/user/UpdateUserInfoRequest.java
+++ b/src/main/java/app/allstackproject/privideo/dto/user/UpdateUserInfoRequest.java
@@ -4,6 +4,7 @@ import app.allstackproject.privideo.common.annotation.AgeTypeConstraint;
 import app.allstackproject.privideo.common.annotation.EnumConstraint;
 import app.allstackproject.privideo.common.enumStatus.GenderType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,12 +14,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateUserInfoRequest {
-
+    @NotNull
     private String newPassword;
 
     @AgeTypeConstraint
     private Integer changedAge;
 
+    @NotNull
     private String confirmPassword;
 
     @EnumConstraint(enumClass = GenderType.class, message = "성별의 유형은 MALE 또는 FEMALE 이어야 합니다.")

--- a/src/main/java/app/allstackproject/privideo/dto/user/UpdateUserInfoRequest.java
+++ b/src/main/java/app/allstackproject/privideo/dto/user/UpdateUserInfoRequest.java
@@ -2,10 +2,7 @@ package app.allstackproject.privideo.dto.user;
 
 import app.allstackproject.privideo.common.annotation.AgeTypeConstraint;
 import app.allstackproject.privideo.common.annotation.EnumConstraint;
-import app.allstackproject.privideo.common.annotation.PasswordConstraint;
 import app.allstackproject.privideo.common.enumStatus.GenderType;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -17,13 +14,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UpdateUserInfoRequest {
 
-    @PasswordConstraint
     private String newPassword;
 
     @AgeTypeConstraint
     private Integer changedAge;
 
-    @PasswordConstraint
     private String confirmPassword;
 
     @EnumConstraint(enumClass = GenderType.class, message = "성별의 유형은 MALE 또는 FEMALE 이어야 합니다.")

--- a/src/main/java/app/allstackproject/privideo/repository/video/VideoRedisRepository.java
+++ b/src/main/java/app/allstackproject/privideo/repository/video/VideoRedisRepository.java
@@ -6,6 +6,7 @@ import app.allstackproject.privideo.common.util.RedisRetryUtil;
 import app.allstackproject.privideo.common.util.RedisUtil;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Repository;
 public class VideoRedisRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private static final long WATCH_SESSION_TTL_HOURS = 2;
 
     public void createWatchSession(String sessionId, Long memberId) {
         String key = RedisUtil.getWatchSessionKey(sessionId);
@@ -28,6 +30,7 @@ public class VideoRedisRepository {
                     sessionData.put(MEMBER_ID, String.valueOf(memberId));
 
                     redisTemplate.opsForHash().putAll(key, sessionData);
+                    redisTemplate.expire(key, WATCH_SESSION_TTL_HOURS, TimeUnit.HOURS);
 
                     log.debug("시청 세션 저장 성공 [sessionId: {}, memberId: {}]", sessionId, memberId);
                 },

--- a/src/main/java/app/allstackproject/privideo/service/organization/OrganizationService.java
+++ b/src/main/java/app/allstackproject/privideo/service/organization/OrganizationService.java
@@ -1,11 +1,13 @@
 package app.allstackproject.privideo.service.organization;
 
 import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.INACTIVE;
 import static app.allstackproject.privideo.common.enumStatus.JoinStatusType.APPROVED;
 import static app.allstackproject.privideo.common.enumStatus.JoinStatusType.PENDING;
 import static app.allstackproject.privideo.common.enumStatus.JoinStatusType.REJECTED;
 import static app.allstackproject.privideo.common.enumStatus.S3ImgType.ORG;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.ALREADY_APPROVED_MEMBER;
+import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.ALREADY_LEAVED_MEMBER;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.ALREADY_REQUESTED_MEMBER;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.DUPLICATE_NICKNAME;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.MEMBER_NOT_FOUND;
@@ -162,13 +164,11 @@ public class OrganizationService {
             organization = organizationRepository.findById(orgId)
                     .orElseThrow(() -> new ApiException(ORGANIZATION_NOT_FOUND));
         } else {
-//            organization = orgRedisRepository.findByCode(orgCode)
-//                    .orElseThrow(() -> new ApiException(INVALID_ORG_CODE));
-//
-//            orgId = organization.getId();
-//
-//            orgRedisRepository.saveOrgCode(orgId, orgCode);
             throw new ApiException(ORG_CODE_NOT_AVAILABLE);
+        }
+
+        if (memberRepository.findByUserIdAndOrganizationIdAndStatus(userId, orgId, INACTIVE).isPresent()) {
+            throw new ApiException(ALREADY_LEAVED_MEMBER);
         }
 
         Optional<Member> existMember = memberRepository.findByUserIdAndOrganizationIdAndStatus(userId, orgId, ACTIVE);

--- a/src/main/java/app/allstackproject/privideo/service/user/UserService.java
+++ b/src/main/java/app/allstackproject/privideo/service/user/UserService.java
@@ -1,7 +1,9 @@
 package app.allstackproject.privideo.service.user;
 
 import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.ACTIVE;
+import static app.allstackproject.privideo.common.enumStatus.BaseStatusType.INACTIVE;
 import static app.allstackproject.privideo.common.enumStatus.JoinStatusType.PENDING;
+import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.ALREADY_LEAVED_USER;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.DB_CONSTRAINT_VIOLATE;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.DUPLICATE_EMAIL;
 import static app.allstackproject.privideo.common.response.status.BaseExceptionResponseStatus.INVALID_ORG_CODE;
@@ -46,6 +48,10 @@ public class UserService {
     private final OrgRedisRepository orgRedisRepository;
 
     public boolean signup(@Valid PostSignupRequest postSignupRequest) {
+        if (userRepository.existsByEmailAndStatus(postSignupRequest.getEmail(), INACTIVE)) {
+            throw new ApiException(ALREADY_LEAVED_USER);
+        }
+
         if (userRepository.existsByEmailAndStatus(postSignupRequest.getEmail(), ACTIVE)) {
             throw new ApiException(DUPLICATE_EMAIL);
         }

--- a/src/main/java/app/allstackproject/privideo/service/user/UserService.java
+++ b/src/main/java/app/allstackproject/privideo/service/user/UserService.java
@@ -106,9 +106,17 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
 
-        validateAndUpdatePassword(user, request);
-        updateUserFields(user, request);
+        user.updateInfo(
+                request.getChangedPhoneNum(),
+                GenderType.valueOf(request.getChangedGender().toUpperCase()),
+                request.getChangedAge()
+        );
 
+        if (request.getNewPassword().isEmpty()) {
+            return true;
+        }
+
+        validateAndUpdatePassword(user, request);
         return true;
     }
 
@@ -122,14 +130,6 @@ public class UserService {
         }
 
         user.changePassword(request.getNewPassword(), passwordEncoder);
-    }
-
-    private void updateUserFields(User user, UpdateUserInfoRequest request) {
-        user.updateInfo(
-                request.getChangedPhoneNum(),
-                GenderType.valueOf(request.getChangedGender().toUpperCase()),
-                request.getChangedAge()
-        );
     }
 
     public boolean deleteUser(Long userId) {


### PR DESCRIPTION
## 📝 요약

- resolved #91 

## 🔖 변경 사항
- [x] 유저 정보 수정 시 비밀번호 변경 안 할 거면 빈 string으로 보냄 -> 백에서 처리해야 함
- [x] 조직 이미지 수정 안됨
  ->  프론트에서 요청 시 `image` 키가 아닌 `img` 키로 보내야 함
- [x] 영상 재생 세션 키 ttl 2시간
- [x] 탈퇴한 회원의 이메일로 재 회원가입 시 500 오류
- [x] 조직 탈퇴 후 재가입 요청 시 500 오류
- [x] 내보내진 멤버의 탈퇴 여부 파악
- [x] 전체 멤버 조회 시 권한 403 에러
  -> 전체 멤버 조회는 super admin의 권한. 프론트에서 해당 API를 호출하는 부분 확인 필요

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 탈퇴 이력(회원·조직멤버) 관련 명확한 오류 상태 추가로 재가입/조직가입 차단 강화
  * 조직 토큰 흐름에서 탈퇴 이력 누락 시 별도 오류 반환

* **버그 수정**
  * 비밀번호 미입력 시 불필요한 검증 제거로 사용자 정보 업데이트 흐름 개선
  * 영상 시청 세션에 자동 만료(TTL 2시간) 적용하여 저장소 효율성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->